### PR TITLE
使用 udev 自动加载驱动

### DIFF
--- a/40-rapoo-keyboard-driver.rules
+++ b/40-rapoo-keyboard-driver.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1c4f", ATTR{idProduct}=="0059", RUN+="/usr/local/bin/install-rapoo-keyboard-driver.sh"

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,9 @@ endif
 
 install:
 	cp -f hid-rapoo.ko /lib/modules/`uname -r`/kernel/drivers/hid/
+	cp -f install-rapoo-keyboard-driver.sh /usr/local/bin/
+	cp -f 40-rapoo-keyboard-driver.rules /etc/udev/rules.d/
 	@depmod
-	@grep -rn hid-rapoo ~/.bash_profile > /dev/null; \
-	if [ $$? -eq 1 ]; then \
-		cat installdriver.sh >> ~/.bash_profile; \
-	fi
-
 clean:
 	rm -rf *.o *~ core .depend .*.cmd *.ko *.mod.c .tmp_versions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Some bugfix for rapoo keyboard where some keys are invalid.
 
 # Quick Usage
-Compile the driver module with make, make install and run ./installdriver.sh.
+Compile the driver module with make, make install and run ./install-rapoo-keyboard-driver.sh.
 
 Job done! Then enjoy typing!
 

--- a/install-rapoo-keyboard-driver.sh
+++ b/install-rapoo-keyboard-driver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #install rapoo v500 driver
 


### PR DESCRIPTION
十分感谢作者提供 rapoo v500 的 linux 驱动.


rmmod 等命令默认是需要 root 权限运行,非 root 用户使用 .bash_profile 方式运行会失败.

原理是利用 udev 插入指定硬件运行自定义脚本而实现的.

参考资料 http://askubuntu.com/questions/536746/commands-not-executing-in-shell-script-run-by-udev 